### PR TITLE
intersection - Do not lose initialization state on combine

### DIFF
--- a/SOURCES/src/datasketches/theta/AggregateIntersection.cpp
+++ b/SOURCES/src/datasketches/theta/AggregateIntersection.cpp
@@ -76,12 +76,13 @@ class ThetaSketchAggregateIntersection : public ThetaSketchAggregateFunction {
             }
 
             do {
-                initialized = aggsOther.getBoolRef(1);
-                if (initialized) {
+                vbool otherInitialized = aggsOther.getBoolRef(1);
+                if (otherInitialized) {
                     auto sketch = compact_theta_sketch_custom::deserialize(aggsOther.getStringRef(0).data(),
                                                                     aggsOther.getStringRef(0).length(),
                                                                     seed);
                     intersection.update(sketch);
+                    initialized = true;
                 }
             } while (aggsOther.next());
 


### PR DESCRIPTION
The initialization state of the sketch can be lost on combine if the main part is initialized but not the other part.
This fix will prevent from un-initializing the sketch