### PR TITLE
build: add Docker instructions

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,95 @@
+# Quick building/compilation guide
+
+## Install Vertica SDK (or SDKs)
+
+Obtain the SDK or SDKs you need from Vertica instances, from Vertica Docker images...
+
+The active SDK should be accessible through `/opt/vertica/sdk` so that the path
+`/opt/vertica/sdk/include/BuildInfo.h` exists and belongs to the wanted SDK.
+
+This may be achieved through the following, assuming the contents of `/opt/vertica/sdk`
+is in the tarball `/tmp/vertica-sdk-24.0.x.tgz`:
+
+```bash
+# 1: create the expected path for a Vertica SDK and make yourself its owner
+sudo mkdir -p /opt/vertica/; sudo chown $(whoami): /opt/vertica
+# 2: create the directory for SDKs in your home
+mkdir -p $HOME/dev/vertica-sdk/24.0.x
+# 3: extract the SDK to the directory you just created
+tar -C $HOME/dev/vertica-sdk/24.0.x -xvf /tmp/vertica-sdk-24.0.x.tgz
+# 4: make this SDK the active SDK
+rm /opt/vertica/sdk; ln -s $HOME/dev/vertica-sdk/24.0.x /opt/vertica/sdk
+# if you want to add other SDKs, repeat steps 2 and 3.
+# if you want to enable another SDK, repeat step 4.
+```
+
+## Enable the Vertica SDK you want to compile against
+
+See previous step.
+
+## Install Docker
+
+Refer to the documentation for your environment.
+
+## Build and run the builder Docker image
+
+Run `./start-build-env.sh` and follow the instructions.
+
+This is an example run:
+
+```bash
+# ./start-build-env.sh
+[+] Building 1.3s (12/12) FINISHED                                                                             docker:default
+ => [internal] load build definition from centos8.Dockerfile                                                             0.0s
+ => => transferring dockerfile: 435B                                                                                     0.0s
+ => [internal] load metadata for docker.io/library/rockylinux:8.5.20220308                                               1.3s
+ => [auth] library/rockylinux:pull token for registry-1.docker.io                                                        0.0s
+ => [internal] load .dockerignore                                                                                        0.0s
+ => => transferring context: 2B                                                                                          0.0s
+ => [1/7] FROM docker.io/library/rockylinux:8.5.20220308@sha256:c7d13ea4d57355aaad6b6ebcdcca50f5be65fc821f54161430f5c25  0.0s
+ => CACHED [2/7] RUN dnf -y install cmake gcc-toolset-9 cmake gcc-toolset-9-gcc-c++                                      0.0s
+ => CACHED [3/7] RUN mkdir -p /opt/vertica/sdk /sources /build                                                           0.0s
+ => CACHED [4/7] RUN useradd builder && chown builder: /opt/vertica /sources/ build                                      0.0s
+ => CACHED [5/7] WORKDIR /build                                                                                          0.0s
+ => CACHED [6/7] RUN echo 'source scl_source enable gcc-toolset-9' >> ~/.bashrc                                          0.0s
+ => CACHED [7/7] RUN echo 'echo "# you may build using: cmake /sources; make;" 1>&2; echo;' >> ~/.bashrc                 0.0s
+ => exporting to image                                                                                                   0.0s
+ => => exporting layers                                                                                                  0.0s
+ => => writing image sha256:d87191b04ef3897d1ec3962e7228acc36e8355e07634d60a937872c81da2b96c                             0.0s
+ => => naming to docker.io/library/vertica-builder-hll-druid:local                                                       0.0s
+vbuilder-hll-druid
+Error response from daemon: No such container: vbuilder-hll-druid
+94d81b98487f2aea8480969ad4f9c2ac5a3b36200c97aa626bf99e44c2d07a02
+Run docker exec -ti vbuilder-hll-druid bash # now
+Then, you may run the following to build
+cmake /sources; make clean; make
+```
+
+## Perform any development you want
+
+You may touch the source code in the SOURCES directory.
+
+## Build and recover built assets
+
+Within the container, run the following:
+
+```bash
+# you may want to cleanup the /build directory
+rm -rf /build/*
+# ensure you're in /build (you should be, by default)
+cd /build
+# prepare the environment with CMake
+# you also want to run that if you modify the CMakeLists.txt  or other components
+cmake /sources
+# build the code
+make
+```
+
+You will find the UDx as a .so file in the build directory of your local copy.
+
+## Build for another SDK
+
+- Perform the SDK change as indicated in this document.
+- Then, **re-run start-build-env.sh** because the container needs to restart to take in
+  account the new SDK.
+- Just build again.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM gcc:8.5.0-buster
+RUN echo deb http://archive.debian.org/debian buster-backports main contrib non-free | tee -a /etc/apt/sources.list
+RUN apt-get update && apt-get -y install cmake/buster-backports
+RUN mkdir -p /opt/vertica/sdk /sources /build
+RUN useradd builder && chown builder: /opt/vertica /sources/ build
+WORKDIR /build
+USER builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,0 @@
-FROM gcc:8.5.0-buster
-RUN echo deb http://archive.debian.org/debian buster-backports main contrib non-free | tee -a /etc/apt/sources.list
-RUN apt-get update && apt-get -y install cmake/buster-backports
-RUN mkdir -p /opt/vertica/sdk /sources /build
-RUN useradd builder && chown builder: /opt/vertica /sources/ build
-WORKDIR /build
-USER builder

--- a/README.md
+++ b/README.md
@@ -21,6 +21,43 @@ make
 
 Additional build options can be enabled by runing ccmake.
 
+## How to build with Docker
+## Get the Vertica SDK from a Vertica instance or a Docker image.
+
+If you have a Vertica deployment, just get the SDK from `/opt/vertica/sdk`
+
+If you don't have one handy, use:
+
+`docker run --rm opentext/vertica-k8s:24.4.0-0 tar -C /opt/vertica -c -v sdk > /tmp/vertica-sdk.tar`
+
+## Install the Vertica SDK somewhere useful
+
+On your dev machine (don't do that on a Vertica server, you'll mess things up)
+
+```bash
+# load the SDK to a dev directory in your home
+mkdir -p ~/dev/vertica-sdks
+cd ~/dev/vertica-sdks
+tar xf /tmp/vertica-sdk.tar
+mv sdk 24.4.0
+# link the expected SDK location to your local SDK copy
+sudo mkdir -p /opt/vertica && sudo chown -R $(id -u) /opt/vertica
+ln -sf ~/dev/vertica-sdks/24.4.0 /opt/vertica/sdk
+```
+
+## Run the build environment
+
+You need Docker and the SDK properly ready in /opt/vertica/sdk. Run `./start-build-env.sh` and then drop to the shell: `docker exec -ti vbuilder-datask bash`
+
+You may then try to build using (inside the container)
+
+```bash
+cd /build
+cmake /sources
+make
+```
+
+
 # Known issues
 In Vertica, each query is given at runtime a pool which depends of the configuration of the database and the context (User, Roles, etc).
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ If you have a Vertica deployment, just get the SDK from `/opt/vertica/sdk`
 
 If you don't have one handy, use:
 
-`docker run --rm opentext/vertica-k8s:24.4.0-0 tar -C /opt/vertica -c -v sdk > /tmp/vertica-sdk.tar`
+```bash
+docker run --rm --entrypoint bash opentext/vertica-k8s:24.4.0-0 -c 'tar -C /opt/vertica -c -v sdk' > /tmp/vertica-sdk.tar
+```
 
 ## Install the Vertica SDK somewhere useful
 

--- a/SOURCES/CMakeLists.txt
+++ b/SOURCES/CMakeLists.txt
@@ -15,17 +15,23 @@ option(BUILD_VERTICA_TEST_DRIVER "Build a test program to show basic functionali
 option(BUILD_TESTS "Build all tests." OFF)
 
 
-## When building for Vertica 11, you need to set specific defines
-file(READ "/opt/vertica/sdk/include/BuildInfo.h" buildinfosdk)
-# message(${buildinfosdk})
+# Here we say where g++ should look for include files
+set(SDK_HOME /opt/vertica/sdk CACHE FILEPATH "Path to the Vertica SDK, by default /opt/vertica/sdk")
+if(NOT EXISTS ${SDK_HOME})
+  message(FATAL_ERROR "Could not build. No SDK found at ${SDK_HOME} (maybe retry with -DSDK_HOME=<sdk_path>).")
+endif()
+set(VERTICA_INCLUDE ${SDK_HOME}/include)
+
+## When building for Vertica 12, you need to set specific defines
+file(READ "${VERTICA_INCLUDE}/BuildInfo.h" buildinfosdk)
 string(REGEX MATCH "#define[ ]+VERTICA_BUILD_ID_SDK_Version_Major[ ]+([0-9]+)" _ ${buildinfosdk})
 set(ver_major ${CMAKE_MATCH_1})
 message("Version", ${ver_major})
-if (${ver_major} LESS_EQUAL 11)
+if (${ver_major} LESS_EQUAL 12)
   add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
-  message("Using CXX11 ABI because Vertica <= 11:", ${ver_major})
+  message("Using CXX11 ABI because Vertica <= 12:", ${ver_major})
 else()
-  message("Not using CXX11 ABI because newer SDK than Vertica 11", ${ver_major})
+  message("Not using CXX11 ABI because newer SDK than Vertica 12", ${ver_major})
 endif()
 
 ## For Vertica 24, you don't need it.

--- a/SOURCES/CMakeLists.txt
+++ b/SOURCES/CMakeLists.txt
@@ -15,6 +15,21 @@ option(BUILD_VERTICA_TEST_DRIVER "Build a test program to show basic functionali
 option(BUILD_TESTS "Build all tests." OFF)
 
 
+## When building for Vertica 11, you need to set specific defines
+file(READ "/opt/vertica/sdk/include/BuildInfo.h" buildinfosdk)
+# message(${buildinfosdk})
+string(REGEX MATCH "#define[ ]+VERTICA_BUILD_ID_SDK_Version_Major[ ]+([0-9]+)" _ ${buildinfosdk})
+set(ver_major ${CMAKE_MATCH_1})
+message("Version", ${ver_major})
+if (${ver_major} LESS_EQUAL 11)
+  add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
+  message("Using CXX11 ABI because Vertica <= 11:", ${ver_major})
+else()
+  message("Not using CXX11 ABI because newer SDK than Vertica 11", ${ver_major})
+endif()
+
+## For Vertica 24, you don't need it.
+
 #############################
 ##  EXTERNAL DEPENDENCIES  ##
 #############################

--- a/SOURCES/CMakeLists.txt
+++ b/SOURCES/CMakeLists.txt
@@ -88,7 +88,7 @@ if (BUILD_VERTICA_LIB)
   add_library(vertica-datasketches SHARED ${VERTICA_DATASKETCHES_SRC} ${VERTICA_SRC})
   add_dependencies(vertica-datasketches datasketches)
 
-  set_target_properties(vertica-datasketches PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+  set_target_properties(vertica-datasketches PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS}")
   include_directories(${DATASKETCHES_INCLUDE})
 
   # Installation process just copies the binary to Vertica lib folder

--- a/SOURCES/vertica-hll-druid.code-workspace
+++ b/SOURCES/vertica-hll-druid.code-workspace
@@ -1,0 +1,17 @@
+{
+	"folders": [
+		{
+			"path": "../../vertica-hll-druid"
+		},
+		{
+			"path": "../../../../../opt/vertica/sdk"
+		},
+		{
+			"path": "../../vertica-hyperloglog"
+		},
+		{
+			"path": ".."
+		}
+	],
+	"settings": {}
+}

--- a/centos8.Dockerfile
+++ b/centos8.Dockerfile
@@ -1,0 +1,8 @@
+FROM rockylinux:8.5.20220308
+RUN dnf -y install cmake gcc-toolset-9 cmake gcc-toolset-9-gcc-c++
+RUN mkdir -p /opt/vertica/sdk /sources /build
+RUN useradd builder && chown builder: /opt/vertica /sources/ build
+WORKDIR /build
+USER builder
+RUN echo 'source scl_source enable gcc-toolset-9' >> ~/.bashrc
+RUN echo 'echo "# you may build using: cmake /sources; make;" 1>&2; echo;' >> ~/.bashrc

--- a/start-build-env.sh
+++ b/start-build-env.sh
@@ -17,7 +17,9 @@ docker kill ${BUILDER_INSTANCE_NAME} || true
 sleep 1
 docker rm ${BUILDER_INSTANCE_NAME} || true
 sleep 1
-docker run --rm --name ${BUILDER_INSTANCE_NAME} -v=$PWD/SOURCES:/sources -v=$PWD/build:/build -v=/opt/vertica/sdk:/opt/vertica/sdk  -d $BUILDER_IMAGE sleep 3600
+docker run --rm --name ${BUILDER_INSTANCE_NAME} -v=$PWD/SOURCES:/sources -v=/opt/vertica/sdk:/opt/vertica/sdk  -d $BUILDER_IMAGE sleep 3600
 echo "Run docker exec -ti ${BUILDER_INSTANCE_NAME} bash # now"
 echo "Then, you may run the following to build"
 echo "cmake /sources; make clean; make"
+echo "once it's done, to recover the library, you may run:"
+echo "docker cp ${BUILDER_INSTANCE_NAME}:/build/libvertica-datasketches.so build/"

--- a/start-build-env.sh
+++ b/start-build-env.sh
@@ -1,13 +1,23 @@
 #!/bin/bash
-docker build -t vertica-builder-ds:local .
+_b_env=${1:-centos8.Dockerfile}
+errout() {
+  _r=$1
+  shift 1;
+  echo $@;
+  exit $_r;
+}
+BUILDER_IMAGE="vertica-builder-ds:local"
+BUILDER_INSTANCE_NAME="vbuilder-datasketches"
+docker build -f ${_b_env} -t ${BUILDER_IMAGE} .
+test -f /opt/vertica/sdk/include/BuildInfo.h || errout 30 "Vertica SDK is missing. Put it in /opt/vertica/sdk so that /opt/vertica/sdk/include/BuildInfo.h exists"
 
 rm -rf build
 mkdir -p build
-docker kill vbuilder-datask || true
+docker kill ${BUILDER_INSTANCE_NAME} || true
 sleep 1
-docker rm vbuilder-datask || true
+docker rm ${BUILDER_INSTANCE_NAME} || true
 sleep 1
-docker run --rm --name vbuilder-datask -v=$PWD/SOURCES:/sources -v=$PWD/build:/build -v=/opt/vertica/sdk:/opt/vertica/sdk  -d vertica-builder-ds:local sleep 3600
-echo "Run docker exec -ti vbuilder-datask bash # now"
+docker run --rm --name ${BUILDER_INSTANCE_NAME} -v=$PWD/SOURCES:/sources -v=$PWD/build:/build -v=/opt/vertica/sdk:/opt/vertica/sdk  -d $BUILDER_IMAGE sleep 3600
+echo "Run docker exec -ti ${BUILDER_INSTANCE_NAME} bash # now"
 echo "Then, you may run the following to build"
 echo "cmake /sources; make clean; make"

--- a/start-build-env.sh
+++ b/start-build-env.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+docker build -t vertica-builder-ds:local .
+
+rm -rf build
+mkdir -p build
+docker kill vbuilder-datask || true
+sleep 1
+docker rm vbuilder-datask || true
+sleep 1
+docker run --rm --name vbuilder-datask -v=$PWD/SOURCES:/sources -v=$PWD/build:/build -v=/opt/vertica/sdk:/opt/vertica/sdk  -d vertica-builder-ds:local sleep 3600
+echo "Run docker exec -ti vbuilder-datask bash # now"
+echo "Then, you may run the following to build"
+echo "cmake /sources; make clean; make"


### PR DESCRIPTION
Hi, I'm a Criteo.

This is a better build option since Vertica supports only G++-8. I made it work decently well with Docker.

I also made it set the right options when working with newer Vertica SDK vs. older Vertica SDK.